### PR TITLE
Demonstrate workaround for rendering body datatypes

### DIFF
--- a/src/main/scala/PersonHttpService.scala
+++ b/src/main/scala/PersonHttpService.scala
@@ -1,0 +1,38 @@
+package com.gettyimages.spray.swagger
+
+import javax.ws.rs.Path
+
+import com.wordnik.swagger.annotations._
+import spray.http.StatusCodes.OK
+import spray.httpx.Json4sSupport
+import spray.routing.HttpService
+
+@Api(value = "/person", description = "Operations about people.", produces = "application/json", position = 2)
+trait PersonHttpService extends HttpService {
+
+  val routes = postPerson
+
+  @ApiOperation(value = "Post a person", notes = "", nickname = "postPerson", httpMethod = "POST")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "body", value = "Person with name", dataType = "Person", required = true, paramType = "body")
+  ))
+  @ApiResponses(Array(
+    new ApiResponse(code = 200, message = "Person got created"),
+    new ApiResponse(code = 500, message = "Internal server error")
+  ))
+  def postPerson =
+    path("person") {
+      post {
+        complete(OK)
+      }
+    }
+
+  // Workaround to show datatype of post request without using it in another route
+  // Related: https://github.com/swagger-api/swagger-core/issues/606
+  // Why is this still showing even though it's set to hidden? See https://github.com/martypitt/swagger-springmvc/issues/447
+  @ApiOperation(value = "IGNORE", notes = "", hidden = true, httpMethod = "GET", response = classOf[Person])
+  protected def showPerson = Unit
+
+}
+
+case class Person(firstname: String, lastname: String)

--- a/src/main/scala/SampleServiceActor.scala
+++ b/src/main/scala/SampleServiceActor.scala
@@ -20,7 +20,11 @@ class SampleServiceActor
       def actorRefFactory = context
     }
 
-    def receive = runRoute(pets.routes ~ users.routes ~ swaggerService.routes ~
+    val persons = new PersonHttpService {
+      def actorRefFactory = context
+    }
+
+    def receive = runRoute(pets.routes ~ users.routes ~ persons.routes ~ swaggerService.routes ~
       get {
         pathPrefix("") { pathEndOrSingleSlash {
             getFromResource("swagger-ui/index.html")
@@ -30,7 +34,7 @@ class SampleServiceActor
       })
 
   val swaggerService = new SwaggerHttpService {
-    override def apiTypes = Seq(typeOf[PetHttpService], typeOf[UserHttpService])
+    override def apiTypes = Seq(typeOf[PetHttpService], typeOf[UserHttpService], typeOf[PersonHttpService])
     override def apiVersion = "2.0"
     override def baseUrl = "/" // let swagger-ui determine the host and port
     override def docsPath = "api-docs"


### PR DESCRIPTION
Add PersonHttpService to demonstrate workaround for rendering body datatypes, which are not used in another route as response type.

It is a really annoying issue, I think it makes sense to have an example to show how to work around it.
